### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ Now press (Ctrl-X) to exit
     
 
 ### STEP 12 install frappe-bench
+    nano /etc/pip.conf
+ADD 
+
+    [global]
+    break-system-packages = true
+
+Install frappe
 
     sudo -H pip3 install frappe-bench
     


### PR DESCRIPTION
when installing frappe on ubnuntu 24 you face new problem 

error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.

this is the solution 

Open Terminal

Run sudo nano /etc/pip.conf

Add following line:

[global]
break-system-packages = true


thanks for this answer in Stackoverflow 
https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3
